### PR TITLE
Spawn multiple gost instances in a single command with --

### DIFF
--- a/cmd/gost/cmd.go
+++ b/cmd/gost/cmd.go
@@ -29,7 +29,7 @@ func (l *stringList) Set(value string) error {
 	return nil
 }
 
-func buildConfigFromCmd(services, nodes stringList) (*config.Config, error) {
+func buildConfigFromCmd(wid int, services, nodes stringList) (*config.Config, error) {
 	cfg := &config.Config{}
 
 	if v := os.Getenv("GOST_PROFILING"); v != "" {
@@ -58,7 +58,7 @@ func buildConfigFromCmd(services, nodes stringList) (*config.Config, error) {
 	var chain *config.ChainConfig
 	if len(nodes) > 0 {
 		chain = &config.ChainConfig{
-			Name: "chain-0",
+			Name: fmt.Sprintf("go-%d@chain-0", wid),
 		}
 		cfg.Chains = append(cfg.Chains, chain)
 	}
@@ -73,7 +73,7 @@ func buildConfigFromCmd(services, nodes stringList) (*config.Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		nodeConfig.Name = "node-0"
+		nodeConfig.Name = fmt.Sprintf("go-%d@node-0", wid)
 
 		var nodes []*config.NodeConfig
 		for _, host := range strings.Split(nodeConfig.Addr, ",") {
@@ -82,7 +82,7 @@ func buildConfigFromCmd(services, nodes stringList) (*config.Config, error) {
 			}
 			nodeCfg := &config.NodeConfig{}
 			*nodeCfg = *nodeConfig
-			nodeCfg.Name = fmt.Sprintf("node-%d", len(nodes))
+			nodeCfg.Name = fmt.Sprintf("go-%d@node-%d", wid, len(nodes))
 			nodeCfg.Addr = host
 			nodes = append(nodes, nodeCfg)
 		}
@@ -91,14 +91,14 @@ func buildConfigFromCmd(services, nodes stringList) (*config.Config, error) {
 		md := metadata.NewMetadata(mc)
 
 		hopConfig := &config.HopConfig{
-			Name:     fmt.Sprintf("hop-%d", i),
+			Name:     fmt.Sprintf("go-%d@hop-%d", wid, i),
 			Selector: parseSelector(mc),
 			Nodes:    nodes,
 		}
 
 		if v := metadata.GetString(md, "bypass"); v != "" {
 			bypassCfg := &config.BypassConfig{
-				Name: fmt.Sprintf("bypass-%d", len(cfg.Bypasses)),
+				Name: fmt.Sprintf("go-%d@bypass-%d", wid, len(cfg.Bypasses)),
 			}
 			if v[0] == '~' {
 				bypassCfg.Reverse = true
@@ -116,7 +116,7 @@ func buildConfigFromCmd(services, nodes stringList) (*config.Config, error) {
 		}
 		if v := metadata.GetString(md, "resolver"); v != "" {
 			resolverCfg := &config.ResolverConfig{
-				Name: fmt.Sprintf("resolver-%d", len(cfg.Resolvers)),
+				Name: fmt.Sprintf("go-%d@resolver-%d", wid, len(cfg.Resolvers)),
 			}
 			for _, rs := range strings.Split(v, ",") {
 				if rs == "" {
@@ -135,7 +135,7 @@ func buildConfigFromCmd(services, nodes stringList) (*config.Config, error) {
 		}
 		if v := metadata.GetString(md, "hosts"); v != "" {
 			hostsCfg := &config.HostsConfig{
-				Name: fmt.Sprintf("hosts-%d", len(cfg.Hosts)),
+				Name: fmt.Sprintf("go-%d@hosts-%d", wid, len(cfg.Hosts)),
 			}
 			for _, s := range strings.Split(v, ",") {
 				ss := strings.SplitN(s, ":", 2)
@@ -179,7 +179,7 @@ func buildConfigFromCmd(services, nodes stringList) (*config.Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		service.Name = fmt.Sprintf("service-%d", i)
+		service.Name = fmt.Sprintf("go-%d@service-%d", wid, i)
 		if chain != nil {
 			if service.Listener.Type == "rtcp" || service.Listener.Type == "rudp" {
 				service.Listener.Chain = chain.Name
@@ -197,7 +197,7 @@ func buildConfigFromCmd(services, nodes stringList) (*config.Config, error) {
 		}
 		if v := metadata.GetString(md, "admission"); v != "" {
 			admCfg := &config.AdmissionConfig{
-				Name: fmt.Sprintf("admission-%d", len(cfg.Admissions)),
+				Name: fmt.Sprintf("go-%d@admission-%d", wid, len(cfg.Admissions)),
 			}
 			if v[0] == '~' {
 				admCfg.Reverse = true
@@ -215,7 +215,7 @@ func buildConfigFromCmd(services, nodes stringList) (*config.Config, error) {
 		}
 		if v := metadata.GetString(md, "bypass"); v != "" {
 			bypassCfg := &config.BypassConfig{
-				Name: fmt.Sprintf("bypass-%d", len(cfg.Bypasses)),
+				Name: fmt.Sprintf("go-%d@bypass-%d", wid, len(cfg.Bypasses)),
 			}
 			if v[0] == '~' {
 				bypassCfg.Reverse = true
@@ -233,7 +233,7 @@ func buildConfigFromCmd(services, nodes stringList) (*config.Config, error) {
 		}
 		if v := metadata.GetString(md, "resolver"); v != "" {
 			resolverCfg := &config.ResolverConfig{
-				Name: fmt.Sprintf("resolver-%d", len(cfg.Resolvers)),
+				Name: fmt.Sprintf("go-%d@resolver-%d", wid, len(cfg.Resolvers)),
 			}
 			for _, rs := range strings.Split(v, ",") {
 				if rs == "" {
@@ -253,7 +253,7 @@ func buildConfigFromCmd(services, nodes stringList) (*config.Config, error) {
 		}
 		if v := metadata.GetString(md, "hosts"); v != "" {
 			hostsCfg := &config.HostsConfig{
-				Name: fmt.Sprintf("hosts-%d", len(cfg.Hosts)),
+				Name: fmt.Sprintf("go-%d@hosts-%d", wid, len(cfg.Hosts)),
 			}
 			for _, s := range strings.Split(v, ",") {
 				ss := strings.SplitN(s, ":", 2)

--- a/cmd/gost/main.go
+++ b/cmd/gost/main.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"sync"
+	"strings"
 	"runtime"
 
 	"github.com/go-gost/core/logger"
@@ -16,138 +18,197 @@ import (
 	xmetrics "github.com/go-gost/x/metrics"
 )
 
+type WorkerSync struct {
+	wg sync.WaitGroup
+	mu sync.Mutex
+}
+
 var (
 	log logger.Logger
-
-	cfgFile      string
-	outputFormat string
-	services     stringList
-	nodes        stringList
-	debug        bool
-	apiAddr      string
-	metricsAddr  string
 )
 
 func init() {
-	var printVersion bool
-
-	flag.Var(&services, "L", "service list")
-	flag.Var(&nodes, "F", "chain node list")
-	flag.StringVar(&cfgFile, "C", "", "configure file")
-	flag.BoolVar(&printVersion, "V", false, "print version")
-	flag.StringVar(&outputFormat, "O", "", "output format, one of yaml|json format")
-	flag.BoolVar(&debug, "D", false, "debug mode")
-	flag.StringVar(&apiAddr, "api", "", "api service address")
-	flag.StringVar(&metricsAddr, "metrics", "", "metrics service address")
-	flag.Parse()
-
-	if printVersion {
-		fmt.Fprintf(os.Stdout, "gost %s (%s %s/%s)\n",
-			version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
-		os.Exit(0)
-	}
-
 	log = xlogger.NewLogger()
 	logger.SetDefault(log)
 }
 
 func main() {
-	cfg := &config.Config{}
-	var err error
-	if len(services) > 0 || apiAddr != "" {
-		cfg, err = buildConfigFromCmd(services, nodes)
-		if err != nil {
-			log.Fatal(err)
-		}
-		if debug && cfg != nil {
-			if cfg.Log == nil {
-				cfg.Log = &config.LogConfig{}
-			}
-			cfg.Log.Level = string(logger.DebugLevel)
-		}
-		if apiAddr != "" {
-			cfg.API = &config.APIConfig{
-				Addr: apiAddr,
-			}
-		}
-		if metricsAddr != "" {
-			cfg.Metrics = &config.MetricsConfig{
-				Addr: metricsAddr,
-			}
-		}
-	} else {
-		if cfgFile != "" {
-			err = cfg.ReadFile(cfgFile)
-		} else {
-			err = cfg.Load()
-		}
-		if err != nil {
-			log.Fatal(err)
+	var ws WorkerSync
+
+	ws.wg.Add(1)  // Gost must exit if any of the workers exit
+
+	// Split os.Args using -- and create a worker with each slice
+	args := strings.Split(" " + strings.Join(os.Args[1:], "  ") + " ", " -- ")
+	if strings.Join(args, "") == "" {
+		// Fix to show gost help if the resulting array is empty
+		args[0] = " "
+	}
+	for wid, wargs := range args {
+		if wargs != "" {
+			go worker(wid, wargs, &ws)
 		}
 	}
+	ws.wg.Wait()
+}
 
-	log = logFromConfig(cfg.Log)
+func worker(id int, args string, ws *WorkerSync) {
+	defer ws.wg.Done()
 
-	logger.SetDefault(log)
+	var (
+		cfgFile      string
+		outputFormat string
+		services     stringList
+		nodes        stringList
+		debug        bool
+		apiAddr      string
+		metricsAddr  string
 
-	if outputFormat != "" {
-		if err := cfg.Write(os.Stdout, outputFormat); err != nil {
-			log.Fatal(err)
+		err          error
+
+		cfg = &config.Config{}
+	)
+
+	init := func () error {
+		var printVersion bool
+
+		wf := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+		wf.Var(&services, "L", "service list")
+		wf.Var(&nodes, "F", "chain node list")
+		wf.StringVar(&cfgFile, "C", "", "configure file")
+		wf.BoolVar(&printVersion, "V", false, "print version")
+		wf.StringVar(&outputFormat, "O", "", "output format, one of yaml|json format")
+		wf.BoolVar(&debug, "D", false, "debug mode")
+		wf.StringVar(&apiAddr, "api", "", "api service address")
+		wf.StringVar(&metricsAddr, "metrics", "", "metrics service address")
+
+		wf.Parse(strings.Fields(args))
+
+		if printVersion {
+			fmt.Fprintf(os.Stdout, "gost %s (%s %s/%s)\n",
+				version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+			os.Exit(0)
+		} else if wf.NFlag() == 0 {
+			wf.Usage()
+			os.Exit(0)
 		}
-		os.Exit(0)
+		return nil
 	}
 
-	if cfg.Profiling != nil {
-		go func() {
-			addr := cfg.Profiling.Addr
-			if addr == "" {
-				addr = ":6060"
-			}
-			log.Info("profiling server on ", addr)
-			log.Fatal(http.ListenAndServe(addr, nil))
-		}()
-	}
-
-	if cfg.API != nil {
-		s, err := buildAPIService(cfg.API)
-		if err != nil {
-			log.Fatal(err)
-		}
-		defer s.Close()
-
-		go func() {
-			log.Info("api service on ", s.Addr())
-			log.Fatal(s.Serve())
-		}()
-	}
-
-	if cfg.Metrics != nil {
-		metrics.SetGlobal(xmetrics.NewMetrics())
-		if cfg.Metrics.Addr != "" {
-			s, err := buildMetricsService(cfg.Metrics)
+	main := func () error {
+		if len(services) > 0 || apiAddr != "" {
+			cfg, err = buildConfigFromCmd(id, services, nodes)
 			if err != nil {
 				log.Fatal(err)
 			}
+			if debug && cfg != nil {
+				if cfg.Log == nil {
+					cfg.Log = &config.LogConfig{}
+				}
+				cfg.Log.Level = string(logger.DebugLevel)
+			}
+			if apiAddr != "" {
+				cfg.API = &config.APIConfig{
+					Addr: apiAddr,
+				}
+			}
+			if metricsAddr != "" {
+				cfg.Metrics = &config.MetricsConfig{
+					Addr: metricsAddr,
+				}
+			}
+		} else {
+			if cfgFile != "" {
+				err = cfg.ReadFile(cfgFile)
+			} else {
+				err = cfg.Load()
+			}
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		log = logFromConfig(cfg.Log)
+
+		logger.SetDefault(log)
+
+		if outputFormat != "" {
+			if err := cfg.Write(os.Stdout, outputFormat); err != nil {
+				log.Fatal(err)
+			}
+			os.Exit(0)
+		}
+
+		if cfg.Profiling != nil {
 			go func() {
-				defer s.Close()
-				log.Info("metrics service on ", s.Addr())
+				addr := cfg.Profiling.Addr
+				if addr == "" {
+					// Each worker uses a different profiling server
+					addr = fmt.Sprintf(":606%d", id)
+				}
+				log.Info("profiling server on ", addr)
+				log.Fatal(http.ListenAndServe(addr, nil))
+			}()
+		}
+
+		if cfg.API != nil {
+			s, err := buildAPIService(cfg.API)
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer s.Close()
+
+			go func() {
+				log.Info("api service on ", s.Addr())
 				log.Fatal(s.Serve())
 			}()
 		}
+
+		if cfg.Metrics != nil {
+			metrics.SetGlobal(xmetrics.NewMetrics())
+			if cfg.Metrics.Addr != "" {
+				s, err := buildMetricsService(cfg.Metrics)
+				if err != nil {
+					log.Fatal(err)
+				}
+				go func() {
+					defer s.Close()
+					log.Info("metrics service on ", s.Addr())
+					log.Fatal(s.Serve())
+				}()
+			}
+		}
+
+		parsing.BuildDefaultTLSConfig(cfg.TLS)
+
+		svcs := buildService(cfg)
+		for _, svc := range svcs {
+			svc := svc
+			go func() {
+				svc.Serve()
+				svc.Close()
+			}()
+		}
+		config.SetGlobal(cfg)
+
+		return nil
 	}
 
-	parsing.BuildDefaultTLSConfig(cfg.TLS)
-
-	services := buildService(cfg)
-	for _, svc := range services {
-		svc := svc
-		go func() {
-			svc.Serve()
-			svc.Close()
-		}()
+	// Using mutex to avoid duplicated service creation race condition
+	ws.mu.Lock()
+	if err := init(); err != nil {
+		log.Fatal(err)
+		return
 	}
+	if err := main(); err != nil {
+		log.Fatal(err)
+		return
+	}
+	ws.mu.Unlock()
 
-	config.SetGlobal(cfg)
+	// Allow local functions to be garbage-collected
+	init = nil
+	main = nil
 
 	select {}
 }


### PR DESCRIPTION
Hi!

This PR adds the multi-instance/cmd-split flag as described in https://github.com/ginuerzh/gost/pull/713 to gost v3.

Unlike the gost v2 version, this time the multi-instance feature truly isolates the gost components that were previously shared in all instances: config files, SSL/TLS certs, logging, metrics, etc.

The following is an adaptation of the example referred in https://github.com/ginuerzh/gost/pull/713.

**Before** this PR these are the steps to create a reverse-socks over SSH:

```sh
# Server
gost -L sshd://:2222

# Client - Terminal/Process 1
gost -L rtcp://127.0.0.1:3333/127.0.0.1:1111 -F sshd://<server-ip>:2222

# Client - Terminal/Process 2
gost -L socks5://127.0.0.1:1111

# Test from Server
curl -s -L -x socks5://127.0.0.1:3333 https://example.com
```

**After** this PR the client no longer needs to use multiple terminals/processes:

```sh
# Server
gost -L sshd://:2222

# Client
gost -L socks5://127.0.0.1:1111 -- -L rtcp://127.0.0.1:3333/127.0.0.1:1111 -F sshd://<server-ip>:2222

# Test from Server
curl -s -L -x socks5://127.0.0.1:3333 https://example.com
```

Check how the instances spawned above (client) are isolated by making them use config files and separating their logs:

```sh
# Save the configuration of the first instance to socks.yaml
gost -L socks5://127.0.0.1:1111 -O yaml > socks.yaml

# Make the first instance log to socks.txt
echo -e 'log:\n  output: ./socks.txt\n  format: text' >> socks.yaml

# Save the configuration of the second instance to rtcp.yaml
gost -L rtcp://127.0.0.1:3333/127.0.0.1:1111 -F sshd://:2222 -O yaml > rtcp.yaml

# Rename services/hops/chains to avoid name conflicts with the first instance
sed -i 's/0@/1@/' rtcp.yaml

# Make the second instance log to rtcp.txt
echo -e 'log:\n  output: ./rtcp.txt\n  format: text' >> rtcp.yaml

# Repeat the example in the code block above with the following as Client
gost -C socks.yaml -- -C rtcp.yaml

# Make the logs a bit more readable by extracting the service and msg content
gawk -i inplace -F'[="]' '{$0="["$NF"] "$7}1' socks.txt rtcp.txt

# Check the logs side by side
pr -w $COLUMNS -m -t socks.txt rtcp.txt
```

For those who would like to try it, these are the steps to build gost v3 with the multi-instance/cmd-split flag feature:

```sh
# Clone my repos and switch to the branch with the feature
git clone -b cmd-split https://github.com/caribpa/go-gost-core

git clone -b cmd-split https://github.com/caribpa/go-gost-x

git clone -b cmd-split https://github.com/caribpa/go-gost

# Tell the local go-gost/x to use the local go-gost/core
cd go-gost-x

go mod edit -replace="github.com/go-gost/core=../go-gost-core"

# Tell the local go-gost/gost to use the local go-gost/core and go-gost/x
cd ../go-gost

go mod edit -replace="github.com/go-gost/core=../go-gost-core"

go mod edit -replace="github.com/go-gost/x=../go-gost-x"

# Clean the module cache
go clean -modcache

# Build gost v3
cd cmd/gost

go build

# Test it!
./gost -L sock5://:1081 -- -L http://:8081 -L sshd://:2222
```

Cheers 😀 