### PR TITLE
Insert services and nodes to loaded config

### DIFF
--- a/cmd/gost/main.go
+++ b/cmd/gost/main.go
@@ -35,7 +35,7 @@ func init() {
 
 	flag.Var(&services, "L", "service list")
 	flag.Var(&nodes, "F", "chain node list")
-	flag.StringVar(&cfgFile, "C", "", "configure file")
+	flag.StringVar(&cfgFile, "C", "", "configuration file")
 	flag.BoolVar(&printVersion, "V", false, "print version")
 	flag.StringVar(&outputFormat, "O", "", "output format, one of yaml|json format")
 	flag.BoolVar(&debug, "D", false, "debug mode")


### PR DESCRIPTION
Currently gost will not load config file if `-L` is given. However [ShadowsocksGostPlugin](https://github.com/segfault-bilibili/ShadowsocksGostPlugin) is using `-L` to pass parameters which enables Shadowsocks-Android to connect to gost. Therefore I think gost should still load config file and then insert things specified in `-L` to the loaded config.

I do the same to `-F` although `-F` does not block loading config because I think it's reasonable just like the case of `-L`.

By the way, I think maybe a new cmdline argument could be added to handle the case where the user really does not want to load any config, especially `gost.json` or `gost.yaml`. However I haven't done it so far.