### PR TITLE
Add initial regression tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,6 @@ cmd/gost/gost
 snap
 
 *.pem
-*.yaml
+/*.yaml
 *.txt
 dist/

--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:3.22
+
+# add iptables for tun/tap and curl for testing
+RUN apk add --no-cache iptables curl

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -1,13 +1,20 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"testing"
+
+	"github.com/testcontainers/testcontainers-go/network"
 )
 
+var SharedNetworkName string
+
 func TestMain(m *testing.M) {
+	ctx := context.Background()
+
 	// Compile the gost binary
 	cmd := exec.Command("go", "build", "-o", "/tmp/gost-test-bin", "../../cmd/gost")
 	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
@@ -17,12 +24,23 @@ func TestMain(m *testing.M) {
 		fmt.Printf("Failed to compile gost: %v\n", err)
 		os.Exit(1)
 	}
+	defer func() {
+		os.Remove("/tmp/gost-test-bin")
+	}()
+
+	// Create a shared Docker network
+	net, err := network.New(ctx)
+	if err != nil {
+		fmt.Printf("Failed to create network: %v\n", err)
+		os.Exit(1)
+	}
+	SharedNetworkName = net.Name
 
 	// Run tests
 	code := m.Run()
 
 	// Cleanup
-	os.Remove("/tmp/gost-test-bin")
+	net.Remove(ctx)
 
 	os.Exit(code)
 }

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -1,0 +1,28 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// Compile the gost binary
+	cmd := exec.Command("go", "build", "-o", "/tmp/gost-test-bin", "../../cmd/gost")
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Printf("Failed to compile gost: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Run tests
+	code := m.Run()
+
+	// Cleanup
+	os.Remove("/tmp/gost-test-bin")
+
+	os.Exit(code)
+}

--- a/tests/e2e/parallel_selector_test.go
+++ b/tests/e2e/parallel_selector_test.go
@@ -8,13 +8,11 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/network"
 )
 
 type ParallelSelectorSuite struct {
 	suite.Suite
 	ctx    context.Context
-	net    *testcontainers.DockerNetwork
 	echoC  testcontainers.Container
 	echoIP string
 }
@@ -22,11 +20,7 @@ type ParallelSelectorSuite struct {
 func (s *ParallelSelectorSuite) SetupSuite() {
 	s.ctx = context.Background()
 
-	net, err := network.New(s.ctx)
-	s.Require().NoError(err)
-	s.net = net
-
-	echoC, err := RunEchoContainer(s.ctx, s.net.Name)
+	echoC, err := RunEchoContainer(s.ctx, SharedNetworkName)
 	s.Require().NoError(err)
 	s.echoC = echoC
 
@@ -39,13 +33,10 @@ func (s *ParallelSelectorSuite) TearDownSuite() {
 	if s.echoC != nil {
 		s.echoC.Terminate(s.ctx)
 	}
-	if s.net != nil {
-		s.net.Remove(s.ctx)
-	}
 }
 
 func (s *ParallelSelectorSuite) TestParallelSelector() {
-	gostC, err := RunGostContainer(s.ctx, s.net.Name, "testdata/parallel_selector/server.yaml")
+	gostC, err := RunGostContainer(s.ctx, SharedNetworkName, "testdata/parallel_selector/server.yaml")
 	s.Require().NoError(err)
 	defer gostC.Terminate(s.ctx)
 

--- a/tests/e2e/parallel_selector_test.go
+++ b/tests/e2e/parallel_selector_test.go
@@ -1,0 +1,66 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/network"
+)
+
+type ParallelSelectorSuite struct {
+	suite.Suite
+	ctx    context.Context
+	net    *testcontainers.DockerNetwork
+	echoC  testcontainers.Container
+	echoIP string
+}
+
+func (s *ParallelSelectorSuite) SetupSuite() {
+	s.ctx = context.Background()
+
+	net, err := network.New(s.ctx)
+	s.Require().NoError(err)
+	s.net = net
+
+	echoC, err := RunEchoContainer(s.ctx, s.net.Name)
+	s.Require().NoError(err)
+	s.echoC = echoC
+
+	echoIP, err := echoC.ContainerIP(s.ctx)
+	s.Require().NoError(err)
+	s.echoIP = echoIP
+}
+
+func (s *ParallelSelectorSuite) TearDownSuite() {
+	if s.echoC != nil {
+		s.echoC.Terminate(s.ctx)
+	}
+	if s.net != nil {
+		s.net.Remove(s.ctx)
+	}
+}
+
+func (s *ParallelSelectorSuite) TestParallelSelector() {
+	gostC, err := RunGostContainer(s.ctx, s.net.Name, "testdata/parallel_selector/server.yaml")
+	s.Require().NoError(err)
+	defer gostC.Terminate(s.ctx)
+
+	// Test the proxy by running curl inside the gost container
+	cmd := []string{"curl", "-v", "-s", "-x", "http://127.0.0.1:8080", fmt.Sprintf("http://%s:5678", s.echoIP)}
+	code, out, err := gostC.Exec(s.ctx, cmd)
+	s.Require().NoError(err)
+
+	body, err := io.ReadAll(out)
+	s.Require().NoError(err)
+	s.Require().Equal(0, code)
+
+	s.Require().Contains(string(body), "hello-gost")
+}
+
+func TestParallelSelectorSuite(t *testing.T) {
+	suite.Run(t, new(ParallelSelectorSuite))
+}

--- a/tests/e2e/testdata/parallel_selector/server.yaml
+++ b/tests/e2e/testdata/parallel_selector/server.yaml
@@ -1,0 +1,30 @@
+services:
+- name: proxy
+  addr: :8080
+  handler:
+    type: http
+    chain: my-chain
+  listener:
+    type: tcp
+
+- name: dummy-1
+  addr: :18081
+  handler:
+    type: http
+
+chains:
+- name: my-chain
+  hops:
+  - name: hop-1
+    selector:
+      strategy: parallel
+    nodes:
+    - name: node-1
+      addr: 127.0.0.1:18081
+      connector:
+        type: http
+    # non existed node
+    - name: node-2
+      addr: 127.0.0.1:18082
+      connector:
+        type: http

--- a/tests/e2e/utils.go
+++ b/tests/e2e/utils.go
@@ -1,0 +1,42 @@
+package e2e
+
+import (
+	"context"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+func RunEchoContainer(ctx context.Context, networkName string) (testcontainers.Container, error) {
+	req := testcontainers.ContainerRequest{
+		Image:        "hashicorp/http-echo:latest",
+		Networks:     []string{networkName},
+		Cmd:          []string{"-text=hello-gost", "-listen=:5678"},
+		ExposedPorts: []string{"5678/tcp"},
+		WaitingFor:   wait.ForHTTP("/").WithPort("5678/tcp"),
+	}
+	return testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+}
+
+func RunGostContainer(ctx context.Context, networkName, yamlPath string) (testcontainers.Container, error) {
+	req := testcontainers.ContainerRequest{
+		FromDockerfile: testcontainers.FromDockerfile{
+			Context:    ".",
+			Dockerfile: "Dockerfile",
+			KeepImage:  true,
+		},
+		Networks: []string{networkName},
+		Files: []testcontainers.ContainerFile{
+			{HostFilePath: "/tmp/gost-test-bin", ContainerFilePath: "/bin/gost", FileMode: 0755},
+			{HostFilePath: yamlPath, ContainerFilePath: "/config.yaml", FileMode: 0644},
+		},
+		Cmd: []string{"/bin/gost", "-C", "/config.yaml"},
+	}
+	return testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+}

--- a/tests/e2e/utils.go
+++ b/tests/e2e/utils.go
@@ -26,6 +26,8 @@ func RunGostContainer(ctx context.Context, networkName, yamlPath string) (testco
 		FromDockerfile: testcontainers.FromDockerfile{
 			Context:    ".",
 			Dockerfile: "Dockerfile",
+			Repo:       "gost-e2e",
+			Tag:        "latest",
 			KeepImage:  true,
 		},
 		Networks: []string{networkName},


### PR DESCRIPTION
There is no regression tests in gost currently, so some bugs have not been revealed until users use it. Regression tests would help to mitigate that problem.

This regress tests uses testcontainers to run gost and other endpoints(like http server) for testing handlers, listeners and protocols.