### PR TITLE
when multiple download links are matched, use the first one.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,7 +66,7 @@ install_gost() {
         ;;
     esac
     get_download_url="$base_url/tags/$version"
-    download_url=$(curl -s "$get_download_url" | awk -F'"' -v re=".*${os}.*${cpu_arch}.*" '/"browser_download_url":/ && $4 ~ re { print $4 }')
+    download_url=$(curl -s "$get_download_url" | awk -F'"' -v re=".*${os}.*${cpu_arch}.*" '/"browser_download_url":/ && $4 ~ re { print $4 }' | head -n 1)
 
     # Download and install the binary
     install_path="/usr/local/bin"


### PR DESCRIPTION
在alpine服务器上运行安装脚本报错：
curl: (3) URL rejected: Malformed input to a URL function

排查后发现，当前版本部分会匹配出来2个版本的下载链接：
gost_3.2.6_linux_amd64.tar.gz
gost_3.2.6_linux_amd64v3.tar.gz

修改后默认取第一个兼容性更好的版本