### PR TITLE
feat: add nftables package to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN cd cmd/gost && \
 
 FROM alpine:3.23
 
-# add iptables for tun/tap
-RUN apk add --no-cache iptables
+# add iptables/nftables for tun/tap
+RUN apk add --no-cache iptables nftables
 
 WORKDIR /bin/
 


### PR DESCRIPTION
nftables is a more modern iptables which support both ipv4 and ipv6