### PR TITLE
chore(release): Make files in tarball owned by root

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,6 +47,9 @@ upx:
 
 archives:
   - format: tar.gz
+    builds_info:
+      group: root
+      owner: root
     # use zip for windows archives
     format_overrides:
     - goos: windows


### PR DESCRIPTION
To eliminate an extra `chown` step after extracting binaries from the tarball on a server.